### PR TITLE
Update Dockerfile to  remove 'go get' as it's no longer supported out…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ENV GO111MODULE=on
 
 ADD . /go/src/github.com/google/web-api-gateway
 
-RUN go get github.com/google/web-api-gateway/server@latest
 RUN go install github.com/google/web-api-gateway/server@latest
 RUN go install github.com/google/web-api-gateway/setuptool@latest
 RUN go install github.com/google/web-api-gateway/connectiontest@latest


### PR DESCRIPTION
…side a module.

Error:
$ sudo docker build -t web-api-gateway .

Sending build context to Docker daemon  14.28MB

Step 1/9 : FROM golang

 ---> 6650307efe4a

Step 2/9 : ENV GO111MODULE=on

 ---> Using cache

 ---> 84443c796153

Step 3/9 : ADD . /go/src/github.com/google/web-api-gateway

 ---> Using cache

 ---> 7e5e0e5e30b8

Step 4/9 : RUN go get github.com/google/web-api-gateway/server@latest

 ---> Running in db360de14e70

go: go.mod file not found in current directory or any parent directory.

        'go get' is no longer supported outside a module.

        To build and install a command, use 'go install' with a version,

        like 'go install example.com/cmd@latest'

        For more information, see https://golang.org/doc/go-get-install-deprecation

        or run 'go help get' or 'go help install'.